### PR TITLE
Implement eapi transport options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@ eos_save_running_config: true
 eos_default_vlan_state: present
 
 resource_version: '2.2'
+gather_config_commands:
+  - command: 'show running-config all | exclude \.\*'
+    output: 'text'

--- a/filter_plugins/config_block.py
+++ b/filter_plugins/config_block.py
@@ -1,19 +1,32 @@
-# (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# Copyright (c) 2017, Arista Networks, Inc.
+# All rights reserved.
 #
-# This file is part of Ansible
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
 #
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
 #
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#   Neither the name of Arista Networks nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARISTA NETWORKS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
 from __future__ import (absolute_import, division, print_function)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,21 +4,24 @@
 # If using Ansible 2.2 or higher, we must use eos_config
 # resource_version is set to 2.2 by default (since most users will be
 # on updated versions), change it if we're running 2.1 or lower.'
+# gather_config_commands is set to the version 2.2+ format by default
 - set_fact:
     resource_version: '2.1'
+    gather_config_commands:
+      - 'show running-config all | exclude \.\*'
   when: ansible_version.major < 2 or
         (ansible_version.major == 2 and ansible_version.minor < 2)
 
 - name: Gather EOS configuration
   eos_command:
-    commands: 'show running-config all | exclude \.\*'
+    commands: "{{ gather_config_commands }}"
     provider: "{{ provider | default(omit) }}"
     auth_pass: "{{ auth_pass | default(omit) }}"
     authorize: "{{ authorize | default(omit) }}"
     host: "{{ host | default(omit) }}"
     password: "{{ password | default(omit) }}"
     port: "{{ port | default(omit) }}"
-    transport: "cli"
+    transport: "{{ transport | default(omit) }}"
     use_ssl: "{{ use_ssl | default(omit) }}"
     username: "{{ username | default(omit) }}"
   register: output

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -12,7 +12,7 @@
     password: "{{ password | default(omit) }}"
     port: "{{ port | default(omit) }}"
     provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
+    transport: "{{ transport | default(omit) }}"
     use_ssl: "{{ use_ssl | default(omit) }}"
     username: "{{ username | default(omit) }}"
   notify: save running config
@@ -29,7 +29,7 @@
     password: "{{ password | default(omit) }}"
     port: "{{ port | default(omit) }}"
     provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
+    transport: "{{ transport | default(omit) }}"
     use_ssl: "{{ use_ssl | default(omit) }}"
     username: "{{ username | default(omit) }}"
   notify: save running config

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -12,7 +12,7 @@
     password: "{{ password | default(omit) }}"
     port: "{{ port | default(omit) }}"
     provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
+    transport: "{{ transport | default(omit) }}"
     use_ssl: "{{ use_ssl | default(omit) }}"
     username: "{{ username | default(omit) }}"
   notify: save running config
@@ -29,7 +29,7 @@
     password: "{{ password | default(omit) }}"
     port: "{{ port | default(omit) }}"
     provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
+    transport: "{{ transport | default(omit) }}"
     use_ssl: "{{ use_ssl | default(omit) }}"
     username: "{{ username | default(omit) }}"
   notify: save running config


### PR DESCRIPTION
Removes hard-coded 'cli' transport and allows eapi to be specified as
the transport for providers, either individually or globally.

Also replaces copyright notice in Python files with current information