### PR TITLE
Update varp_mac_addr template and testcases

### DIFF
--- a/templates/varp_mac_addr.j2
+++ b/templates/varp_mac_addr.j2
@@ -2,12 +2,25 @@
 #jinja2: trim_blocks: False
 #jinja2: lstrip_blocks: False
 
+{# From EOS 4.17 and up, removing the ip virtual-router mac-address #}
+{# is done by setting the addr to 00:00:00:00:00:00. We need to check #}
+{# the version and process the removal of the mac addr appropriately #}
+{% set version = _eos_config | re_search("! device: .*\(.*, EOS-(.*)\)$") %}
+{% set eos_417_up = version.group(1) | version_compare("4.17", ">=") %}
+
 {% if virtual_mac_addr %}
 
 ip virtual-router mac-address {{ virtual_mac_addr }}
 
 {% else %}
+   {% if eos_417_up %}
+
+ip virtual-router mac-address 00:00:00:00:00:00
+
+   {% else %}
 
 no ip virtual-router mac-address
+
+   {% endif %} # eos_417_up
 
 {% endif %}

--- a/test/testcases/varp_mac_addr.yml
+++ b/test/testcases/varp_mac_addr.yml
@@ -7,7 +7,7 @@ testcases:
     arguments:
       virtual_mac_addr: 00:1c:29:00:00:73
     setup: |
-      no ip virtual-router mac-address
+      ip virtual-router mac-address 00:00:00:00:00:00
     present: |
       ip virtual-router mac-address 00:1c:29:00:00:73
 
@@ -16,8 +16,6 @@ testcases:
       virtual_mac_addr: ''
     setup: |
       ip virtual-router mac-address 00:1c:29:00:00:75
-    present: |
-      no ip virtual-router mac-address
     absent: |
       ip virtual-router mac-address 00:1c:29:00:00:75
 


### PR DESCRIPTION
Changes in EOS 4.17 and up require different handling for
removing the ip virtual-router mac-address. This change addresses
those changes by filtering for the EOS version and generating
the appropriate command.